### PR TITLE
creates MeasurementUnit model, closes #9

### DIFF
--- a/.env.development.local
+++ b/.env.development.local
@@ -1,0 +1,4 @@
+POSTGRES_USER=development_user
+POSTGRES_PASSWORD=development_password
+POSTGRES_HOST=localhost
+POSTGRES_DB=cookpendium_development

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@
 
 .env
 .env.test.local
+.env.development.local	

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :test do
   gem 'faker', '~> 3.2'
   gem 'rspec-watcher'
 
-  gem 'vcr', '~> 6.0.0'
+  gem 'vcr', github: 'vcr/vcr'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/vcr/vcr.git
+  revision: 08b71207924ded5b75f05d93e947888fae5fca38
+  specs:
+    vcr (6.2.0)
+      base64
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -113,7 +120,7 @@ GEM
       activerecord (>= 4.2, < 7.2)
       request_store (~> 1.0)
     hashdiff (1.1.0)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
     irb (1.6.3)
@@ -128,9 +135,9 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.19.1)
+    loofah (2.22.0)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -139,7 +146,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    minitest (5.18.0)
+    minitest (5.20.0)
     msgpack (1.7.0)
     multipart-post (2.3.0)
     net-imap (0.3.4)
@@ -152,9 +159,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.14.2-arm64-darwin)
+    nokogiri (1.16.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.2-x86_64-linux)
+    nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.2.2.0)
@@ -163,8 +170,8 @@ GEM
     public_suffix (5.0.4)
     puma (5.6.5)
       nio4r (~> 2.0)
-    racc (1.6.2)
-    rack (2.2.6.4)
+    racc (1.7.3)
+    rack (2.2.8)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4.3)
@@ -181,11 +188,13 @@ GEM
       activesupport (= 7.0.4.3)
       bundler (>= 1.15.0)
       railties (= 7.0.4.3)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.5.0)
-      loofah (~> 2.19, >= 2.19.1)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
     rails-i18n (7.0.8)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
@@ -197,7 +206,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -206,7 +215,7 @@ GEM
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -263,7 +272,7 @@ GEM
       rubocop-performance (~> 1.16.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
-    thor (1.2.1)
+    thor (1.3.0)
     timeout (0.3.2)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -272,7 +281,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    vcr (6.0.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -285,7 +293,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   arm64-darwin-22
@@ -314,7 +322,7 @@ DEPENDENCIES
   stimulus-rails
   turbo-rails
   tzinfo-data
-  vcr (~> 6.0.0)
+  vcr!
   web-console
   webmock
 

--- a/app/models/concerns/measurable.rb
+++ b/app/models/concerns/measurable.rb
@@ -1,8 +1,0 @@
-# Concern for models that have a unit of measurement
-module Measurable
-  extend ActiveSupport::Concern
-
-  included do
-    enum unit: MeasuringUnits::UNITS
-  end
-end

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# this model is used to store the measurement units for cooking, such as grams, cups, etc.
+class MeasurementUnit < ApplicationRecord
+  translates :name, :abbreviation
+
+  validates :name, presence: true
+end

--- a/app/models/recipe_ingredient.rb
+++ b/app/models/recipe_ingredient.rb
@@ -2,11 +2,9 @@
 
 # Declares the relationship between recipes and ingredients, including the unit of measurement and quantity
 class RecipeIngredient < ApplicationRecord
-  include Measurable
-
   belongs_to :recipe
   belongs_to :ingredient
+  belongs_to :measurement_unit
 
-  validates :quantity, presence: true, numericality: {greater_than: 0}
-  validates :unit, presence: true
+  validates :quantity, presence: true, numericality: { greater_than: 0 }
 end

--- a/app/models/recipe_step_ingredient.rb
+++ b/app/models/recipe_step_ingredient.rb
@@ -2,8 +2,9 @@
 
 # Declares the relationship between recipe steps and ingredients, including the unit of measurement and quantity
 class RecipeStepIngredient < ApplicationRecord
-  include Measurable
-
   belongs_to :recipe_step
   belongs_to :ingredient
+  belongs_to :measurement_unit
+
+  validates :quantity, presence: true, numericality: { greater_than: 0 }
 end

--- a/app/services/ai_tools/recipe_parser.rb
+++ b/app/services/ai_tools/recipe_parser.rb
@@ -57,7 +57,7 @@ module AITools
       <<~HEREDOC
         -- ingredient name (string)
         -- quantity (number)
-        -- unit (string), one of the following: #{MeasuringUnits::UNITS.keys.join(', ')}
+        -- unit (string), as standard as possible, such as 'grams', 'cups', 'pinches', 'tablespoons', 'teaspoons', 'pounds', 'ounces', etc.
       HEREDOC
     end
 

--- a/db/migrate/20240103193025_create_measurement_units.rb
+++ b/db/migrate/20240103193025_create_measurement_units.rb
@@ -1,0 +1,17 @@
+class CreateMeasurementUnits < ActiveRecord::Migration[7.0]
+  def change
+    create_table :measurement_units do |t|
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        MeasurementUnit.create_translation_table! name: { type: :string, null: false }, abbreviation: :string
+      end
+
+      dir.down do
+        MeasurementUnit.drop_translation_table!
+      end
+    end
+  end
+end

--- a/db/migrate/20240103193929_add_measurement_unit_to_recipe_ingredients.rb
+++ b/db/migrate/20240103193929_add_measurement_unit_to_recipe_ingredients.rb
@@ -1,0 +1,5 @@
+class AddMeasurementUnitToRecipeIngredients < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :recipe_ingredients, :measurement_unit, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20240103194017_add_measurement_unit_to_recipe_step_ingredients.rb
+++ b/db/migrate/20240103194017_add_measurement_unit_to_recipe_step_ingredients.rb
@@ -1,0 +1,5 @@
+class AddMeasurementUnitToRecipeStepIngredients < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :recipe_step_ingredients, :measurement_unit, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20240103194643_remove_unit_from_recipe_step_ingredient_and_recipe_ingredient.rb
+++ b/db/migrate/20240103194643_remove_unit_from_recipe_step_ingredient_and_recipe_ingredient.rb
@@ -1,0 +1,6 @@
+class RemoveUnitFromRecipeStepIngredientAndRecipeIngredient < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :recipe_step_ingredients, :unit, :integer
+    remove_column :recipe_ingredients, :unit, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_29_200707) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_03_194643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,28 +47,44 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_29_200707) do
     t.index ["grocery_section_id"], name: "index_ingredients_on_grocery_section_id"
   end
 
+  create_table "measurement_unit_translations", force: :cascade do |t|
+    t.bigint "measurement_unit_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name", null: false
+    t.string "abbreviation"
+    t.index ["locale"], name: "index_measurement_unit_translations_on_locale"
+    t.index ["measurement_unit_id"], name: "index_measurement_unit_translations_on_measurement_unit_id"
+  end
+
+  create_table "measurement_units", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "recipe_ingredients", force: :cascade do |t|
     t.bigint "recipe_id", null: false
     t.float "quantity"
     t.bigint "ingredient_id", null: false
-    t.integer "unit"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "measurement_unit_id", null: false
     t.index ["ingredient_id"], name: "index_recipe_ingredients_on_ingredient_id"
+    t.index ["measurement_unit_id"], name: "index_recipe_ingredients_on_measurement_unit_id"
     t.index ["recipe_id"], name: "index_recipe_ingredients_on_recipe_id"
-    t.index ["unit"], name: "index_recipe_ingredients_on_unit"
   end
 
   create_table "recipe_step_ingredients", force: :cascade do |t|
     t.bigint "recipe_step_id", null: false
     t.float "quantity"
     t.bigint "ingredient_id", null: false
-    t.integer "unit"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "measurement_unit_id", null: false
     t.index ["ingredient_id"], name: "index_recipe_step_ingredients_on_ingredient_id"
+    t.index ["measurement_unit_id"], name: "index_recipe_step_ingredients_on_measurement_unit_id"
     t.index ["recipe_step_id"], name: "index_recipe_step_ingredients_on_recipe_step_id"
-    t.index ["unit"], name: "index_recipe_step_ingredients_on_unit"
   end
 
   create_table "recipe_step_translations", force: :cascade do |t|
@@ -107,8 +123,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_29_200707) do
 
   add_foreign_key "ingredients", "grocery_sections"
   add_foreign_key "recipe_ingredients", "ingredients"
+  add_foreign_key "recipe_ingredients", "measurement_units"
   add_foreign_key "recipe_ingredients", "recipes"
   add_foreign_key "recipe_step_ingredients", "ingredients"
+  add_foreign_key "recipe_step_ingredients", "measurement_units"
   add_foreign_key "recipe_step_ingredients", "recipe_steps"
   add_foreign_key "recipe_steps", "recipes"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,0 @@
-9.times do |i|
-  Recipe.create(
-    name: "Recipe #{i + 1}",
-    ingredients: "227g tub clotted cream, 25g butter, 1 tsp cornflour,100g parmesan, grated nutmeg, 250g fresh fettuccine or tagliatelle, snipped chives or chopped parsley to serve (optional)",
-    instruction: "In a medium saucepan, stir the clotted cream, butter, and cornflour over a low-ish heat and bring to a low simmer. Turn off the heat and keep warm."
-  )
-end

--- a/spec/factories/measurement_units.rb
+++ b/spec/factories/measurement_units.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :measurement_unit do
+    
+  end
+end

--- a/spec/models/measurement_unit_spec.rb
+++ b/spec/models/measurement_unit_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MeasurementUnit, type: :model do
+  it { should validate_presence_of(:name) }
+end

--- a/spec/models/recipe_step_ingredient_spec.rb
+++ b/spec/models/recipe_step_ingredient_spec.rb
@@ -1,7 +1,7 @@
 # spec/models/recipe_ingredient_spec.rb
 require 'rails_helper'
 
-RSpec.describe RecipeIngredient, type: :model do
+RSpec.describe RecipeStepIngredient, type: :model do
   it { should validate_presence_of(:quantity) }
   it { should validate_numericality_of(:quantity).is_greater_than(0) }
   it { should belong_to(:measurement_unit) }


### PR DESCRIPTION
Refactors units from enums in the models into their own model.
Doing this for flexibility on creating new unforeseen units, and dynamic setting of translations in the future.